### PR TITLE
Rework light palette

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,80 +228,80 @@ The theme is available for a variety of applications and is constantly being upd
   </tr>
   <tr>
     <td><img src="assets/palette/dusk/circles/background.svg" width="12"/></td>
-    <td>Pale Parchment</td>
-    <td><code>#f5f0eb</code></td>
-    <td><code>rgb(245, 240, 235)</code></td>
-    <td><code>hsl(30°, 33.33%, 94.12%)</code></td>
+    <td>Pale Shore</td>
+    <td><code>#f0f3f4</code></td>
+    <td><code>rgb(240, 243, 244)</code></td>
+    <td><code>hsl(195.0°, 15.4%, 94.9%)</code></td>
   </tr>
   <tr>
     <td><img src="assets/palette/dusk/circles/currentline.svg" width="12"/></td>
-    <td>Weathered Stone</td>
-    <td><code>#e8e4de</code></td>
-    <td><code>rgb(232, 228, 222)</code></td>
-    <td><code>hsl(35.94°, 17.85%, 89.02%)</code></td>
+    <td>Coastal Mist</td>
+    <td><code>#e2e6e8</code></td>
+    <td><code>rgb(226, 230, 232)</code></td>
+    <td><code>hsl(200.0°, 11.5%, 89.8%)</code></td>
   </tr>
   <tr>
     <td><img src="assets/palette/dusk/circles/foreground.svg" width="12"/></td>
     <td>Abyssal Ink</td>
     <td><code>#1e2029</code></td>
     <td><code>rgb(30, 32, 41)</code></td>
-    <td><code>hsl(229.03°, 15.52%, 13.92%)</code></td>
+    <td><code>hsl(229.1°, 15.5%, 13.9%)</code></td>
   </tr>
   <tr>
     <td><img src="assets/palette/dusk/circles/comment.svg" width="12"/></td>
     <td>Faded Rune</td>
-    <td><code>#7081d0</code></td>
-    <td><code>rgb(112, 129, 208)</code></td>
-    <td><code>hsl(229.38°, 50.53%, 62.75%)</code></td>
+    <td><code>#5b73dc</code></td>
+    <td><code>rgb(91, 115, 220)</code></td>
+    <td><code>hsl(228.8°, 64.8%, 61.0%)</code></td>
   </tr>
   <tr>
     <td><img src="assets/palette/dusk/circles/cyan.svg" width="12"/></td>
     <td>Twilight Teal</td>
-    <td><code>#04d1f9</code></td>
-    <td><code>rgb(4, 209, 249)</code></td>
-    <td><code>hsl(189.8°, 96.84%, 49.61%)</code></td>
+    <td><code>#0ad6ff</code></td>
+    <td><code>rgb(10, 214, 255)</code></td>
+    <td><code>hsl(190.0°, 100.0%, 52.0%)</code></td>
   </tr>
   <tr>
     <td><img src="assets/palette/dusk/circles/green.svg" width="12"/></td>
     <td>Dusk Moss</td>
-    <td><code>#37f499</code></td>
-    <td><code>rgb(55, 244, 153)</code></td>
-    <td><code>hsl(151.11°, 89.57%, 58.63%)</code></td>
+    <td><code>#38ff9f</code></td>
+    <td><code>rgb(56, 255, 159)</code></td>
+    <td><code>hsl(151.1°, 100.0%, 61.0%)</code></td>
   </tr>
   <tr>
     <td><img src="assets/palette/dusk/circles/orange.svg" width="12"/></td>
     <td>Ember Glow</td>
-    <td><code>#f7c67f</code></td>
-    <td><code>rgb(247, 198, 127)</code></td>
-    <td><code>hsl(35.5°, 88.24%, 73.33%)</code></td>
+    <td><code>#ffaf4d</code></td>
+    <td><code>rgb(255, 175, 77)</code></td>
+    <td><code>hsl(33.0°, 100.0%, 65.1%)</code></td>
   </tr>
   <tr>
     <td><img src="assets/palette/dusk/circles/pink.svg" width="12"/></td>
     <td>Fading Rose</td>
-    <td><code>#f265b5</code></td>
-    <td><code>rgb(242, 101, 181)</code></td>
-    <td><code>hsl(325.96°, 84.43%, 67.25%)</code></td>
+    <td><code>#fb5bb6</code></td>
+    <td><code>rgb(251, 91, 182)</code></td>
+    <td><code>hsl(325.9°, 95.2%, 67.1%)</code></td>
   </tr>
   <tr>
     <td><img src="assets/palette/dusk/circles/purple.svg" width="12"/></td>
     <td>Vesper Violet</td>
-    <td><code>#a48cf2</code></td>
-    <td><code>rgb(164, 140, 242)</code></td>
-    <td><code>hsl(254.12°, 79.69%, 74.9%)</code></td>
+    <td><code>#8a69f7</code></td>
+    <td><code>rgb(138, 105, 247)</code></td>
+    <td><code>hsl(253.9°, 89.9%, 69.0%)</code></td>
   </tr>
   <tr>
     <td><img src="assets/palette/dusk/circles/red.svg" width="12"/></td>
     <td>Dusk Crimson</td>
-    <td><code>#f16c75</code></td>
-    <td><code>rgb(241, 108, 117)</code></td>
-    <td><code>hsl(355.94°, 82.61%, 68.43%)</code></td>
+    <td><code>#fb5b66</code></td>
+    <td><code>rgb(251, 91, 102)</code></td>
+    <td><code>hsl(355.9°, 95.2%, 67.1%)</code></td>
   </tr>
   <tr>
     <td><img src="assets/palette/dusk/circles/yellow.svg" width="12"/></td>
     <td>Last Light Yellow</td>
-    <td><code>#f1fc79</code></td>
-    <td><code>rgb(241, 252, 121)</code></td>
-    <td><code>hsl(65.04°, 95.62%, 73.14%)</code></td>
+    <td><code>#fff952</code></td>
+    <td><code>rgb(255, 249, 82)</code></td>
+    <td><code>hsl(57.9°, 100.0%, 66.1%)</code></td>
   </tr>
 </table>
 </details>

--- a/assets/palette/deploy-circles.sh
+++ b/assets/palette/deploy-circles.sh
@@ -69,14 +69,14 @@ deploy_palette "abyss" \
 
 # Dusk palette
 deploy_palette "dusk" \
-  background  "#f5f0eb" \
-  currentline "#e8e4de" \
+  background  "#f0f3f4" \
+  currentline "#e2e6e8" \
   foreground  "#1e2029" \
-  comment     "#7081d0" \
-  cyan        "#04d1f9" \
-  green       "#37f499" \
-  orange      "#f7c67f" \
-  pink        "#f265b5" \
-  purple      "#a48cf2" \
-  red         "#f16c75" \
-  yellow      "#f1fc79"
+  comment     "#5b73dc" \
+  cyan        "#0ad6ff" \
+  green       "#38ff9f" \
+  orange      "#ffaf4d" \
+  pink        "#fb5bb6" \
+  purple      "#8a69f7" \
+  red         "#fb5b66" \
+  yellow      "#fff952"

--- a/assets/palette/dusk/circles/background.svg
+++ b/assets/palette/dusk/circles/background.svg
@@ -1,3 +1,3 @@
 <svg height="24" width="24" xmlns="http://www.w3.org/2000/svg">
-  <circle r="12" cx="12" cy="12" fill="#f5f0eb" />
+  <circle r="12" cx="12" cy="12" fill="#f0f3f4" />
 </svg>

--- a/assets/palette/dusk/circles/comment.svg
+++ b/assets/palette/dusk/circles/comment.svg
@@ -1,3 +1,3 @@
 <svg height="24" width="24" xmlns="http://www.w3.org/2000/svg">
-  <circle r="12" cx="12" cy="12" fill="#7081d0" />
+  <circle r="12" cx="12" cy="12" fill="#5b73dc" />
 </svg>

--- a/assets/palette/dusk/circles/currentline.svg
+++ b/assets/palette/dusk/circles/currentline.svg
@@ -1,3 +1,3 @@
 <svg height="24" width="24" xmlns="http://www.w3.org/2000/svg">
-  <circle r="12" cx="12" cy="12" fill="#e8e4de" />
+  <circle r="12" cx="12" cy="12" fill="#e2e6e8" />
 </svg>

--- a/assets/palette/dusk/circles/cyan.svg
+++ b/assets/palette/dusk/circles/cyan.svg
@@ -1,3 +1,3 @@
 <svg height="24" width="24" xmlns="http://www.w3.org/2000/svg">
-  <circle r="12" cx="12" cy="12" fill="#04d1f9" />
+  <circle r="12" cx="12" cy="12" fill="#0ad6ff" />
 </svg>

--- a/assets/palette/dusk/circles/green.svg
+++ b/assets/palette/dusk/circles/green.svg
@@ -1,3 +1,3 @@
 <svg height="24" width="24" xmlns="http://www.w3.org/2000/svg">
-  <circle r="12" cx="12" cy="12" fill="#37f499" />
+  <circle r="12" cx="12" cy="12" fill="#38ff9f" />
 </svg>

--- a/assets/palette/dusk/circles/orange.svg
+++ b/assets/palette/dusk/circles/orange.svg
@@ -1,3 +1,3 @@
 <svg height="24" width="24" xmlns="http://www.w3.org/2000/svg">
-  <circle r="12" cx="12" cy="12" fill="#f7c67f" />
+  <circle r="12" cx="12" cy="12" fill="#ffaf4d" />
 </svg>

--- a/assets/palette/dusk/circles/pink.svg
+++ b/assets/palette/dusk/circles/pink.svg
@@ -1,3 +1,3 @@
 <svg height="24" width="24" xmlns="http://www.w3.org/2000/svg">
-  <circle r="12" cx="12" cy="12" fill="#f265b5" />
+  <circle r="12" cx="12" cy="12" fill="#fb5bb6" />
 </svg>

--- a/assets/palette/dusk/circles/purple.svg
+++ b/assets/palette/dusk/circles/purple.svg
@@ -1,3 +1,3 @@
 <svg height="24" width="24" xmlns="http://www.w3.org/2000/svg">
-  <circle r="12" cx="12" cy="12" fill="#a48cf2" />
+  <circle r="12" cx="12" cy="12" fill="#8a69f7" />
 </svg>

--- a/assets/palette/dusk/circles/red.svg
+++ b/assets/palette/dusk/circles/red.svg
@@ -1,3 +1,3 @@
 <svg height="24" width="24" xmlns="http://www.w3.org/2000/svg">
-  <circle r="12" cx="12" cy="12" fill="#f16c75" />
+  <circle r="12" cx="12" cy="12" fill="#fb5b66" />
 </svg>

--- a/assets/palette/dusk/circles/yellow.svg
+++ b/assets/palette/dusk/circles/yellow.svg
@@ -1,3 +1,3 @@
 <svg height="24" width="24" xmlns="http://www.w3.org/2000/svg">
-  <circle r="12" cx="12" cy="12" fill="#f1fc79" />
+  <circle r="12" cx="12" cy="12" fill="#fff952" />
 </svg>


### PR DESCRIPTION
- Backgrounds hue rotated from warm orange-parchment (30–36°) to cool blue-grey (195–200°). This puts the surface in the same colour family as cyan and green, ending the clash.
- Accents received saturations boost only (or near-only) to give them more presence on a cool white surface.