### PR TITLE
docs: add lich port

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,6 +421,15 @@ New entries go on top.
       <th>Description</th>
     </tr>
     <tr>
+      <td><a href="https://github.com/omartelo/lich">lich</a></td>
+      <td>
+        <a href="https://github.com/omartelo/eldritch-lich"
+          >omartelo/eldritch-lich</a
+        >
+      </td>
+      <td>A desktop harness that runs coding agents side by side</td>
+    </tr>
+    <tr>
       <td><a href="https://sourcegit-scm.github.io">SourceGit</a></td>
       <td><a href="https://github.com/sourcegit-scm/sourcegit-theme">sourcegit-scm/sourcegit-theme</a></td>
       <td>Windows/macOS/Linux GUI client for GIT users</td>


### PR DESCRIPTION
Adds an Eldritch port for [lich](https://github.com/omartelo/lich), a desktop
harness that runs coding agents (Claude Code, Codex, opencode, Crush) side by
side in one window.

Port: [omartelo/eldritch-lich](https://github.com/omartelo/eldritch-lich)

- All three palettes: Cthulhu, Abyss and Dusk, each a variant of one installable
  theme pack.
- Colors come from `assets/palette/<variant>/colors.css`; the role mapping
  follows `SPEC.md`, and the terminal palettes follow the Alacritty port, which
  is the upstream carrying all three variants.
- The light variant swaps a handful of terminal slots for their darker Abyss
  siblings — neon on near-white left dim TUI text unreadable. Every substitution
  stays inside the Eldritch family and is documented in the port's README.
- Repository is built from `eldritch-repo-template`, with a screenshot per
  variant.

Happy to move it under the organization if you would rather host it there — in
that case, please consider this a request to become a contributor.
